### PR TITLE
Improve strip torrent root folder

### DIFF
--- a/src/app/upgrade.h
+++ b/src/app/upgrade.h
@@ -122,7 +122,6 @@ bool upgrade(bool ask = true)
     if (oldResumeWasEmpty)
         Utils::Fs::forceRemove(oldResumeFilename);
 
-
     QString backupFolderPath = Utils::Fs::expandPathAbs(Utils::Fs::QDesktopServicesDataLocation() + "BT_backup");
     QDir backupFolderDir(backupFolderPath);
     QStringList backupFiles = backupFolderDir.entryList(QStringList() << QLatin1String("*.fastresume"), QDir::Files, QDir::Unsorted);

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -783,7 +783,9 @@ bool Session::deleteTorrent(const QString &hash, bool deleteLocalFiles)
 
     // Remove it from session
     if (deleteLocalFiles) {
-        m_savePathsToRemove[torrent->hash()] = torrent->rootPath(true);
+        QString rootPath = torrent->rootPath(true);
+        if (!rootPath.isEmpty())
+            m_savePathsToRemove[torrent->hash()] = rootPath;
         m_nativeSession->remove_torrent(torrent->nativeHandle(), libt::session::delete_files);
     }
     else {

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -291,6 +291,9 @@ QString TorrentHandle::savePath(bool actual) const
 
 QString TorrentHandle::rootPath(bool actual) const
 {
+    if ((filesCount() > 1) && !hasRootFolder())
+        return QString();
+
     QString firstFilePath = filePath(0);
     const int slashIndex = firstFilePath.indexOf("/");
     if (slashIndex >= 0)
@@ -303,8 +306,10 @@ QString TorrentHandle::contentPath(bool actual) const
 {
     if (filesCount() == 1)
         return QDir(savePath(actual)).absoluteFilePath(filePath(0));
-    else
+    else if (hasRootFolder())
         return rootPath(actual);
+    else
+        return savePath(actual);
 }
 
 bool TorrentHandle::hasRootFolder() const

--- a/src/base/bittorrent/torrenthandle.cpp
+++ b/src/base/bittorrent/torrenthandle.cpp
@@ -124,7 +124,6 @@ TorrentState::operator int() const
     return m_value;
 }
 
-    , createSubfolder(in.createSubfolder)
 // TorrentHandle
 
 #define SAFE_CALL(func, ...) \
@@ -182,6 +181,7 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     , m_ratioLimit(data.ratioLimit)
     , m_tempPathDisabled(data.disableTempPath)
     , m_hasMissingFiles(false)
+    , m_hasRootFolder(data.hasRootFolder)
     , m_pauseAfterRecheck(false)
     , m_needSaveResumeData(false)
 {
@@ -190,6 +190,8 @@ TorrentHandle::TorrentHandle(Session *session, const libtorrent::torrent_handle 
     if (!data.resumed) {
         setSequentialDownload(data.sequential);
         if (hasMetadata()) {
+            if (filesCount() == 1)
+                m_hasRootFolder = false;
             if (m_session->isAppendExtensionEnabled())
                 appendExtensionsToIncompleteFiles();
         }
@@ -214,8 +216,8 @@ QString TorrentHandle::name() const
     if (name.isEmpty())
         name = Utils::String::fromStdString(m_nativeStatus.name);
 
-    if (name.isEmpty())
-        name = Utils::String::fromStdString(m_torrentInfo.origFiles().name());
+    if (name.isEmpty() && hasMetadata())
+        name = Utils::String::fromStdString(m_torrentInfo.nativeInfo()->orig_files().name());
 
     if (name.isEmpty())
         name = m_hash;
@@ -303,6 +305,11 @@ QString TorrentHandle::contentPath(bool actual) const
         return QDir(savePath(actual)).absoluteFilePath(filePath(0));
     else
         return rootPath(actual);
+}
+
+bool TorrentHandle::hasRootFolder() const
+{
+    return m_hasRootFolder;
 }
 
 QString TorrentHandle::nativeActualSavePath() const
@@ -1436,6 +1443,7 @@ void TorrentHandle::handleSaveResumeDataAlert(libtorrent::save_resume_data_alert
     resumeData["qBt-name"] = Utils::String::toStdString(m_name);
     resumeData["qBt-seedStatus"] = m_hasSeedStatus;
     resumeData["qBt-tempPathDisabled"] = m_tempPathDisabled;
+    resumeData["qBt-hasRootFolder"] = m_hasRootFolder;
 
     m_session->handleTorrentResumeDataReady(this, resumeData);
 }
@@ -1543,6 +1551,10 @@ void TorrentHandle::handleMetadataReceivedAlert(libt::metadata_received_alert *p
     updateStatus();
     if (m_session->isAppendExtensionEnabled())
         appendExtensionsToIncompleteFiles();
+    if (!m_hasRootFolder)
+        m_torrentInfo.stripRootFolder();
+    if (filesCount() == 1)
+        m_hasRootFolder = false;
     m_session->handleTorrentMetadataReceived(this);
 
     if (isPaused()) {

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -199,6 +199,9 @@ namespace BitTorrent
         //    file4
         //
         //
+        // Torrent A* (Torrent A in "strip root folder" mode)
+        //
+        //
         // Torrent B (singlefile)
         //
         // torrentB/
@@ -215,6 +218,7 @@ namespace BitTorrent
         // |   |           rootPath           |                contentPath                 |
         // |---|------------------------------|--------------------------------------------|
         // | A | /home/user/torrents/torrentA | /home/user/torrents/torrentA               |
+        // | A*|           <empty>            | /home/user/torrents                        |
         // | B | /home/user/torrents/torrentB | /home/user/torrents/torrentB/subdir1/file1 |
         // | C | /home/user/torrents/file1    | /home/user/torrents/file1                  |
 

--- a/src/base/bittorrent/torrenthandle.h
+++ b/src/base/bittorrent/torrenthandle.h
@@ -91,7 +91,7 @@ namespace BitTorrent
         bool sequential;
         bool hasSeedStatus;
         bool skipChecking;
-        bool createSubfolder;
+        bool hasRootFolder;
         TriStateBool addForced;
         TriStateBool addPaused;
         // for new torrents
@@ -221,6 +221,8 @@ namespace BitTorrent
         QString savePath(bool actual = false) const;
         QString rootPath(bool actual = false) const;
         QString contentPath(bool actual = false) const;
+
+        bool hasRootFolder() const;
 
         int filesCount() const;
         int piecesCount() const;
@@ -385,7 +387,7 @@ namespace BitTorrent
         Session *const m_session;
         libtorrent::torrent_handle m_nativeHandle;
         libtorrent::torrent_status m_nativeStatus;
-        TorrentState  m_state;
+        TorrentState m_state;
         TorrentInfo m_torrentInfo;
         SpeedMonitor m_speedMonitor;
 
@@ -409,6 +411,7 @@ namespace BitTorrent
         qreal m_ratioLimit;
         bool m_tempPathDisabled;
         bool m_hasMissingFiles;
+        bool m_hasRootFolder;
 
         bool m_pauseAfterRecheck;
         bool m_needSaveResumeData;

--- a/src/base/bittorrent/torrentinfo.h
+++ b/src/base/bittorrent/torrentinfo.h
@@ -76,11 +76,10 @@ namespace BitTorrent
         QList<QUrl> urlSeeds() const;
         QByteArray metadata() const;
         QStringList filesForPiece(int pieceIndex) const;
-        libtorrent::file_storage files() const;
-        libtorrent::file_storage origFiles() const;
 
         void renameFile(uint index, const QString &newPath);
-        void remapFiles(libtorrent::file_storage const &fileStorage);
+        void stripRootFolder();
+
         boost::intrusive_ptr<libtorrent::torrent_info> nativeInfo() const;
 
     private:

--- a/src/gui/properties/propertieswidget.cpp
+++ b/src/gui/properties/propertieswidget.cpp
@@ -314,10 +314,8 @@ void PropertiesWidget::loadTorrentInfos(BitTorrent::TorrentHandle *const torrent
       label_created_by_val->setText(m_torrent->creator());
 
       // List files in torrent
-      BitTorrent::TorrentInfo info = m_torrent->info();
-      libtorrent::file_storage files = info.files();
-      PropListModel->model()->setupModelData(info);
-      if (!(info.filesCount() > 1 && files.name().empty()))
+      PropListModel->model()->setupModelData(m_torrent->info());
+      if ((m_torrent->filesCount() > 1) && (PropListModel->model()->rowCount() == 1))
           filesList->setExpanded(PropListModel->index(0, 0), true);
 
       // Load file priorities


### PR DESCRIPTION
Fix issue when you rename the "root item" in the "Add New Torrent" dialog
and uncheck "Create subfolder", it will create the subfolder with the
renamed name.
Fix PropertiesWidget first folder is expanded after app restart.
Strip root folder if torrent was added via magnet link.
Fix crash when you get name of torrent without metadata.
